### PR TITLE
Update sync_products.py

### DIFF
--- a/woocommerceconnector/sync_products.py
+++ b/woocommerceconnector/sync_products.py
@@ -259,7 +259,9 @@ def create_item_variants(
             woocommerce_item_variant = {
                 "id": variant.get("id"),
                 "woocommerce_variant_id": variant.get("id"),
-                "name": woocommerce_item.get("name"),
+                "name": variant.get("mini_desc"),
+                "woocommerce_description": variant.get("description"),
+                "description": variant.get("description"),
                 "item_code": str(
                     variant.get("id")
                 ),  # + " " + woocommerce_item.get("name"),


### PR DESCRIPTION
Now the Variants become the correct name(title) from basket short description (mini_desc) and the woocommerce_description and description become the correct description from the variant and not from the template.tem